### PR TITLE
Fix P2P message validation and host parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -326,7 +326,7 @@ async def run_node(port: int, host: str, connect_to: str | None, fund: int, data
         await writer.drain()
         logger.info("🔄 Sent state sync to new peer")
 
-    network._on_peer_connected = on_peer_connected
+    network.register_on_peer_connected(on_peer_connected)
 
     await network.start(port=port, host=host)
 

--- a/minichain/p2p.py
+++ b/minichain/p2p.py
@@ -43,6 +43,18 @@ class P2PNetwork:
             raise ValueError("handler_callback must be callable")
         self._handler_callback = handler_callback
 
+    def register_on_peer_connected(self, handler_callback):
+        if not callable(handler_callback):
+            raise ValueError("handler_callback must be callable")
+        self._on_peer_connected = handler_callback
+
+    async def _notify_peer_connected(self, writer, error_message):
+        if self._on_peer_connected:
+            try:
+                await self._on_peer_connected(writer)
+            except Exception:
+                logger.exception(error_message)
+
     async def start(self, port: int = 9000, host: str = "127.0.0.1"):
         """Start listening for incoming peer connections on the given port."""
         self._port = port
@@ -80,11 +92,7 @@ class P2PNetwork:
                 self._listen_to_peer(reader, writer, f"{host}:{port}")
             )
             self._listen_tasks.append(task)
-            if self._on_peer_connected:
-                try:
-                    await self._on_peer_connected(writer)
-                except Exception:
-                    logger.exception("Network: Error during outbound peer sync")
+            await self._notify_peer_connected(writer, "Network: Error during outbound peer sync")
             logger.info("Network: Connected to peer %s:%d", host, port)
             return True
         except Exception as exc:
@@ -103,11 +111,7 @@ class P2PNetwork:
         self._peers.append((reader, writer))
         task = asyncio.create_task(self._listen_to_peer(reader, writer, addr))
         self._listen_tasks.append(task)
-        if self._on_peer_connected:
-            try:
-                await self._on_peer_connected(writer)
-            except Exception:
-                logger.exception("Network: Error during peer sync")
+        await self._notify_peer_connected(writer, "Network: Error during peer sync")
 
     def _validate_transaction_payload(self, payload):
         if not isinstance(payload, dict):
@@ -206,13 +210,10 @@ class P2PNetwork:
     def _validate_message(self, message):
         if not isinstance(message, dict):
             return False
-        # Allow _peer_addr field added by _listen_to_peer
         required_fields = {"type", "data"}
         if not required_fields.issubset(set(message)):
             return False
-        # Reject messages with unexpected fields (except _peer_addr)
-        allowed_fields = {"type", "data", "_peer_addr"}
-        if not set(message).issubset(allowed_fields):
+        if not set(message).issubset(required_fields):
             return False
 
         msg_type = message.get("type")
@@ -271,9 +272,6 @@ class P2PNetwork:
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     logger.warning("Network: Malformed message from %s", addr)
                     continue
-                if isinstance(data, dict):
-                    data["_peer_addr"] = addr
-
                 if not self._validate_message(data):
                     logger.warning("Network: Invalid message schema from %s", addr)
                     continue
@@ -284,6 +282,7 @@ class P2PNetwork:
                     logger.info("Network: Duplicate %s ignored from %s", msg_type, addr)
                     continue
                 self._mark_seen(msg_type, payload)
+                data["_peer_addr"] = addr
 
                 if self._handler_callback:
                     try:


### PR DESCRIPTION
## Problem
When starting a second MiniChain node and connecting to the first node, the following issues occurred:

1. **AttributeError**: `'P2PNetwork' object has no attribute 'set_on_peer_connected'`
2. **OSError**: Missing host parameter in `run_node` function
3. **Invalid message schema warnings**: The `_validate_message` method strictly checked for `{"type", "data"}` fields, but `_listen_to_peer` adds `_peer_addr` field, causing validation to fail

## Solution
1. Added missing `host` parameter to `run_node` function in `main.py`
2. Changed `network.set_on_peer_connected()` to `network._on_peer_connected = on_peer_connected`
3. Updated `P2PNetwork.start()` method to accept `host` parameter
4. Modified `_validate_message` to allow `_peer_addr` field in addition to `type` and `data`

## Testing
- All 41 existing tests pass
- Manual testing shows nodes can now connect without validation errors

## Changes
- `main.py`: Fixed function signature and method call
- `minichain/p2p.py`: Added host parameter and fixed message validation logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nodes can bind to configurable host addresses (not limited to localhost).
  * Added a formal peer-connected callback registration so handlers can be attached more predictably.

* **Improvements**
  * Centralized peer-connected notification and error handling for more consistent behavior.
  * Relaxed peer message validation to allow required fields plus controlled additional metadata while preserving protocol integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->