### PR TITLE
fix: fund wallet before peer connect

### DIFF
--- a/main.py
+++ b/main.py
@@ -330,6 +330,11 @@ async def run_node(port: int, connect_to: str | None, fund: int, datadir: str | 
 
     await network.start(port=port, host=host)
 
+    # Fund this node's wallet so it can transact in the demo
+    if fund > 0:
+        chain.state.credit_mining_reward(pk, reward=fund)
+        logger.info("💰 Funded %s... with %d coins", pk[:12], fund)
+
     # Connect to a seed peer if requested
     if connect_to:
         try:
@@ -337,11 +342,6 @@ async def run_node(port: int, connect_to: str | None, fund: int, datadir: str | 
             await network.connect_to_peer(host, int(peer_port))
         except ValueError:
             logger.error("Invalid --connect format. Use host:port")
-
-    # Fund this node's wallet so it can transact in the demo
-    if fund > 0:
-        chain.state.credit_mining_reward(pk, reward=fund)
-        logger.info("💰 Funded %s... with %d coins", pk[:12], fund)
 
     try:
         await cli_loop(sk, pk, chain, mempool, network)


### PR DESCRIPTION
###  Addressed Issues:


  ## Summary
  - move initial `--fund` credit ahead of peer connection during node startup
  - ensure peers see the funded account state during initial sync instead of pre-fund state
  - keep the change scoped to startup ordering only



###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [ x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [ x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x ] My code follows the project's code style and conventions
- [x ] If applicable, I have made corresponding changes or additions to the documentation
- [x ] If applicable, I have made corresponding changes or additions to tests
- [x ] My changes generate no new warnings or errors
- [ x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x ] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [ x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the sequence of operations during node startup to ensure wallet funding occurs immediately after network initialization, before establishing peer connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->