### PR TITLE
[OPTIMIZE] Implement lazy hashing cache for Transaction IDs

### DIFF
--- a/minichain/transaction.py
+++ b/minichain/transaction.py
@@ -6,11 +6,14 @@ from .serialization import canonical_json_bytes, canonical_json_hash
 
 
 class Transaction:
-    # 1. List the fields that, if changed, should break the cache
     _TX_FIELDS = {"sender", "receiver", "amount", "nonce", "data", "timestamp", "signature"}
 
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name in self._TX_FIELDS and hasattr(self, "_cached_tx_id"):
+            super().__setattr__("_cached_tx_id", None)
+
     def __init__(self, sender, receiver, amount, nonce, data=None, signature=None, timestamp=None):
-        # We set these first
         self.sender = sender
         self.receiver = receiver
         self.amount = amount
@@ -18,54 +21,26 @@ class Transaction:
         self.data = data
         self.timestamp = timestamp if timestamp else round(time.time() * 1000)
         self.signature = signature
-        
-        # Initialize cache last
         self._cached_tx_id = None
 
-    # 2. The "Watcher" function
-    def __setattr__(self, name, value):
-        # Perform the actual assignment
-        super().__setattr__(name, value)
-        # If a core field was changed, and the cache exists, kill the cache
-        if name in self._TX_FIELDS and hasattr(self, "_cached_tx_id"):
-            super().__setattr__("_cached_tx_id", None)
-
     def to_dict(self):
-        return {
-            "sender": self.sender,
-            "receiver": self.receiver,
-            "amount": self.amount,
-            "nonce": self.nonce,
-            "data": self.data,
-            "timestamp": self.timestamp,
-            "signature": self.signature,
-        }
+        return {"sender": self.sender, "receiver": self.receiver, "amount": self.amount,
+                "nonce": self.nonce, "data": self.data, "timestamp": self.timestamp,
+                "signature": self.signature}
 
     def to_signing_dict(self):
-        return {
-            "sender": self.sender,
-            "receiver": self.receiver,
-            "amount": self.amount,
-            "nonce": self.nonce,
-            "data": self.data,
-            "timestamp": self.timestamp,
-        }
+        return {"sender": self.sender, "receiver": self.receiver, "amount": self.amount,
+                "nonce": self.nonce, "data": self.data, "timestamp": self.timestamp}
 
     @classmethod
     def from_dict(cls, payload: dict):
-        return cls(
-            sender=payload["sender"],
-            receiver=payload.get("receiver"),
-            amount=payload["amount"],
-            nonce=payload["nonce"],
-            data=payload.get("data"),
-            signature=payload.get("signature"),
-            timestamp=payload.get("timestamp"),
-        )
+        return cls(sender=payload["sender"], receiver=payload.get("receiver"),
+                   amount=payload["amount"], nonce=payload["nonce"],
+                   data=payload.get("data"), signature=payload.get("signature"),
+                   timestamp=payload.get("timestamp"))
 
     @property
     def hash_payload(self):
-        """Returns the bytes to be signed."""
         return canonical_json_bytes(self.to_signing_dict())
 
     @property
@@ -77,18 +52,14 @@ class Transaction:
     def sign(self, signing_key: SigningKey):
         if signing_key.verify_key.encode(encoder=HexEncoder).decode() != self.sender:
             raise ValueError("Signing key does not match sender")
-        signed = signing_key.sign(self.hash_payload)
-        # Setting this now automatically clears the cache because of __setattr__!
-        self.signature = signed.signature.hex()
+        self.signature = signing_key.sign(self.hash_payload).signature.hex()
 
     def verify(self):
         if not self.signature:
             return False
-
         try:
-            verify_key = VerifyKey(self.sender, encoder=HexEncoder)
-            verify_key.verify(self.hash_payload, bytes.fromhex(self.signature))
+            VerifyKey(self.sender, encoder=HexEncoder).verify(
+                self.hash_payload, bytes.fromhex(self.signature))
             return True
-
         except (BadSignatureError, CryptoError, ValueError, TypeError):
             return False

--- a/minichain/transaction.py
+++ b/minichain/transaction.py
@@ -8,10 +8,17 @@ from .serialization import canonical_json_bytes, canonical_json_hash
 class Transaction:
     _TX_FIELDS = frozenset({"sender", "receiver", "amount", "nonce", "data", "timestamp", "signature"})
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value) -> None:
+        if name in self._TX_FIELDS and getattr(self, "_sealed", False):
+            raise AttributeError(f"Transaction is sealed; cannot modify '{name}'")
         super().__setattr__(name, value)
         if name in self._TX_FIELDS and hasattr(self, "_cached_tx_id"):
             super().__setattr__("_cached_tx_id", None)
+
+    @staticmethod
+    def _normalize_ts(ts) -> int:
+        ts = int(ts)
+        return ts * 1000 if ts < 1e12 else ts
 
     def __init__(self, sender, receiver, amount, nonce, data=None, signature=None, timestamp=None):
         self.sender = sender
@@ -19,9 +26,10 @@ class Transaction:
         self.amount = amount
         self.nonce = nonce
         self.data = data
-        self.timestamp = timestamp if timestamp is not None else round(time.time() * 1000)
+        self.timestamp = self._normalize_ts(timestamp) if timestamp is not None else round(time.time() * 1000)
         self.signature = signature
         self._cached_tx_id = None
+        self._sealed = False
 
     def to_dict(self):
         return {"sender": self.sender, "receiver": self.receiver, "amount": self.amount,
@@ -53,6 +61,7 @@ class Transaction:
         if signing_key.verify_key.encode(encoder=HexEncoder).decode() != self.sender:
             raise ValueError("Signing key does not match sender")
         self.signature = signing_key.sign(self.hash_payload).signature.hex()
+        self._sealed = True
 
     def verify(self):
         if not self.signature:

--- a/minichain/transaction.py
+++ b/minichain/transaction.py
@@ -6,22 +6,29 @@ from .serialization import canonical_json_bytes, canonical_json_hash
 
 
 class Transaction:
+    # 1. List the fields that, if changed, should break the cache
+    _TX_FIELDS = {"sender", "receiver", "amount", "nonce", "data", "timestamp", "signature"}
+
     def __init__(self, sender, receiver, amount, nonce, data=None, signature=None, timestamp=None):
-        self.sender = sender        # Public key (Hex str)
-        self.receiver = receiver    # Public key (Hex str) or None for Deploy
+        # We set these first
+        self.sender = sender
+        self.receiver = receiver
         self.amount = amount
         self.nonce = nonce
-        self.data = data            # Preserve None (do NOT normalize to "")
-        if timestamp is None:
-            self.timestamp = round(time.time() * 1000)  # New tx: seconds → ms
-        elif timestamp > 1e12:
-            self.timestamp = int(timestamp)              # Already in ms (from network)
-        else:
-            self.timestamp = round(timestamp * 1000)     # Seconds → ms
-        self.signature = signature  # Hex str
+        self.data = data
+        self.timestamp = timestamp if timestamp else round(time.time() * 1000)
+        self.signature = signature
         
-        # 1. Initialize the cache placeholder
+        # Initialize cache last
         self._cached_tx_id = None
+
+    # 2. The "Watcher" function
+    def __setattr__(self, name, value):
+        # Perform the actual assignment
+        super().__setattr__(name, value)
+        # If a core field was changed, and the cache exists, kill the cache
+        if name in self._TX_FIELDS and hasattr(self, "_cached_tx_id"):
+            super().__setattr__("_cached_tx_id", None)
 
     def to_dict(self):
         return {
@@ -63,21 +70,16 @@ class Transaction:
 
     @property
     def tx_id(self):
-        """Deterministic identifier for the signed transaction, cached for performance."""
-        # 2. Check the cache before re-calculating
         if self._cached_tx_id is None:
             self._cached_tx_id = canonical_json_hash(self.to_dict())
         return self._cached_tx_id
 
     def sign(self, signing_key: SigningKey):
-        # Validate that the signing key matches the sender
         if signing_key.verify_key.encode(encoder=HexEncoder).decode() != self.sender:
             raise ValueError("Signing key does not match sender")
         signed = signing_key.sign(self.hash_payload)
+        # Setting this now automatically clears the cache because of __setattr__!
         self.signature = signed.signature.hex()
-        
-        # 3. Invalidate the cache because the signature (and thus the tx_id) changed
-        self._cached_tx_id = None
 
     def verify(self):
         if not self.signature:

--- a/minichain/transaction.py
+++ b/minichain/transaction.py
@@ -19,6 +19,9 @@ class Transaction:
         else:
             self.timestamp = round(timestamp * 1000)     # Seconds → ms
         self.signature = signature  # Hex str
+        
+        # 1. Initialize the cache placeholder
+        self._cached_tx_id = None
 
     def to_dict(self):
         return {
@@ -60,8 +63,11 @@ class Transaction:
 
     @property
     def tx_id(self):
-        """Deterministic identifier for the signed transaction."""
-        return canonical_json_hash(self.to_dict())
+        """Deterministic identifier for the signed transaction, cached for performance."""
+        # 2. Check the cache before re-calculating
+        if self._cached_tx_id is None:
+            self._cached_tx_id = canonical_json_hash(self.to_dict())
+        return self._cached_tx_id
 
     def sign(self, signing_key: SigningKey):
         # Validate that the signing key matches the sender
@@ -69,6 +75,9 @@ class Transaction:
             raise ValueError("Signing key does not match sender")
         signed = signing_key.sign(self.hash_payload)
         self.signature = signed.signature.hex()
+        
+        # 3. Invalidate the cache because the signature (and thus the tx_id) changed
+        self._cached_tx_id = None
 
     def verify(self):
         if not self.signature:
@@ -80,8 +89,4 @@ class Transaction:
             return True
 
         except (BadSignatureError, CryptoError, ValueError, TypeError):
-            # Covers:
-            # - Invalid signature
-            # - Malformed public key hex
-            # - Invalid hex in signature
             return False

--- a/minichain/transaction.py
+++ b/minichain/transaction.py
@@ -6,7 +6,7 @@ from .serialization import canonical_json_bytes, canonical_json_hash
 
 
 class Transaction:
-    _TX_FIELDS = {"sender", "receiver", "amount", "nonce", "data", "timestamp", "signature"}
+    _TX_FIELDS = frozenset({"sender", "receiver", "amount", "nonce", "data", "timestamp", "signature"})
 
     def __setattr__(self, name, value):
         super().__setattr__(name, value)
@@ -19,7 +19,7 @@ class Transaction:
         self.amount = amount
         self.nonce = nonce
         self.data = data
-        self.timestamp = timestamp if timestamp else round(time.time() * 1000)
+        self.timestamp = timestamp if timestamp is not None else round(time.time() * 1000)
         self.signature = signature
         self._cached_tx_id = None
 

--- a/minichain/transaction.py
+++ b/minichain/transaction.py
@@ -60,6 +60,7 @@ class Transaction:
         try:
             VerifyKey(self.sender, encoder=HexEncoder).verify(
                 self.hash_payload, bytes.fromhex(self.signature))
-            return True
         except (BadSignatureError, CryptoError, ValueError, TypeError):
             return False
+        else:
+            return True

--- a/minichain/transaction.py
+++ b/minichain/transaction.py
@@ -17,8 +17,11 @@ class Transaction:
 
     @staticmethod
     def _normalize_ts(ts) -> int:
-        ts = int(ts)
-        return ts * 1000 if ts < 1e12 else ts
+        # Multiply by 1000 and round to preserve ms if it's a standard timestamp (seconds)
+        if ts < 1e12:
+            return round(ts * 1000)
+        # If it's already in milliseconds (>= 1e12), just ensure it's an integer
+        return int(ts)
 
     def __init__(self, sender, receiver, amount, nonce, data=None, signature=None, timestamp=None):
         self.sender = sender

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,31 +14,23 @@ def test_tx_caching():
         nonce=1
     )
 
-    print(f"--- Initial State ---")
-    print(f"Cache value: {tx._cached_tx_id}") # Should be None
+    # 2. Assert Initial State (The "None" check you were worried about)
+    assert tx._cached_tx_id is None
 
-    # 2. First access (triggers calculation)
+    # 3. First access (triggers calculation)
     first_id = tx.tx_id
-    print(f"\n--- After First Access ---")
-    print(f"Calculated ID: {first_id}")
-    print(f"Cache value: {tx._cached_tx_id}") # Should now be the hash
+    assert tx._cached_tx_id == first_id
+    assert tx._cached_tx_id is not None
 
-    # 3. Second access (should be instant)
+    # 4. Second access (should be an instant lookup)
     second_id = tx.tx_id
-    print(f"\n--- After Second Access ---")
-    print(f"Is it the same ID? {first_id == second_id}")
-    
-    # 4. Signing (should clear cache)
-    print(f"\n--- Signing Transaction ---")
+    assert second_id == first_id
+
+    # 5. Signing (must invalidate/clear the cache)
     tx.sign(sk)
-    print(f"Cache value after sign: {tx._cached_tx_id}") # Should be None again
+    assert tx._cached_tx_id is None
 
-    # 5. Access after signing (re-calculates with signature)
+    # 6. Access after signing (must re-calculate)
     signed_id = tx.tx_id
-    print(f"\n--- After Accessing Signed TX ---")
-    print(f"New Signed ID: {signed_id}")
-    print(f"Cache value: {tx._cached_tx_id}")
-    print(f"Did ID change? {signed_id != first_id}")
-
-if __name__ == "__main__":
-    test_tx_caching()
+    assert tx._cached_tx_id == signed_id
+    assert signed_id != first_id

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,7 +15,6 @@ def test_tx_caching_efficiency():
 
     # We 'patch' the hashing function to count how many times it's called
     with patch('minichain.transaction.canonical_json_hash') as mock_hash:
-        # Give it a dummy return value so the code doesn't crash
         mock_hash.return_value = "mocked_hash_value"
 
         # 1. First Access: Should trigger the hash calculation
@@ -28,13 +27,31 @@ def test_tx_caching_efficiency():
         assert res2 == "mocked_hash_value"
         assert mock_hash.call_count == 1  # <--- THIS proves the cache worked!
 
-        # 3. Invalidate via Mutation: Changing a field clears the cache
-        tx.amount = 200
-        assert tx._cached_tx_id is None
+        # 3. Comprehensive Invalidation: Changing ANY field must clear the cache
+        mutations = {
+            "sender": "new_sender_hex",
+            "receiver": "new_receiver",
+            "amount": 200,
+            "nonce": 2,
+            "data": "new_data",
+            "timestamp": 1234567890,
+            "signature": "fake_signature_hex"
+        }
 
-        # 4. Third Access: Should trigger calculation again (count becomes 2)
-        _ = tx.tx_id
-        assert mock_hash.call_count == 2
+        expected_calls = 1
+        for field, new_value in mutations.items():
+            # Mutate the field dynamically
+            setattr(tx, field, new_value)
+            
+            # Prove the cache was instantly killed
+            assert tx._cached_tx_id is None, f"Cache failed to clear when mutating {field}"
+            
+            # Access ID again, which forces a re-calculation
+            _ = tx.tx_id
+            
+            # Prove the hashing math ran exactly one more time
+            expected_calls += 1
+            assert mock_hash.call_count == expected_calls, f"Hash did not recalculate for {field}"
 
 def test_signed_tx_is_sealed():
     """Verifies that a signed transaction clears cache, changes ID, and cannot be modified."""

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,38 +1,43 @@
 import pytest
+from unittest.mock import patch
 from minichain.transaction import Transaction
 from nacl.signing import SigningKey
 from nacl.encoding import HexEncoder
 
-
-def test_tx_caching():
+def test_tx_caching_efficiency():
+    """
+    Verifies that the expensive hashing math is only performed once 
+    and skipped on subsequent accesses (Memoization proof).
+    """
     sk = SigningKey.generate()
     sender_hex = sk.verify_key.encode(encoder=HexEncoder).decode()
     tx = Transaction(sender=sender_hex, receiver="addr", amount=100, nonce=1)
 
-    assert tx._cached_tx_id is None
-    first_id = tx.tx_id
-    assert tx._cached_tx_id == first_id
-    assert tx.tx_id == first_id  # second access, same result
+    # We 'patch' the hashing function to count how many times it's called
+    with patch('minichain.transaction.canonical_json_hash') as mock_hash:
+        # Give it a dummy return value so the code doesn't crash
+        mock_hash.return_value = "mocked_hash_value"
 
-    tx.sign(sk)
-    assert tx._cached_tx_id is None
+        # 1. First Access: Should trigger the hash calculation
+        res1 = tx.tx_id
+        assert res1 == "mocked_hash_value"
+        assert mock_hash.call_count == 1
 
-    signed_id = tx.tx_id
-    assert signed_id != first_id
-    assert tx._cached_tx_id == signed_id
+        # 2. Second Access: Should return the cached value (count remains 1)
+        res2 = tx.tx_id
+        assert res2 == "mocked_hash_value"
+        assert mock_hash.call_count == 1  # <--- THIS proves the cache worked!
 
+        # 3. Invalidate via Mutation: Changing a field clears the cache
+        tx.amount = 200
+        assert tx._cached_tx_id is None
 
-def test_tx_mutation_clears_cache():
-    tx = Transaction(sender="alice", receiver="bob", amount=100, nonce=1)
-    original_id = tx.tx_id
-    assert tx._cached_tx_id is not None
-
-    tx.amount = 500
-    assert tx._cached_tx_id is None
-    assert tx.tx_id != original_id
+        # 4. Third Access: Should trigger calculation again (count becomes 2)
+        _ = tx.tx_id
+        assert mock_hash.call_count == 2
 
 def test_signed_tx_is_sealed():
-    """Verifies that a signed transaction cannot be modified."""
+    """Verifies that a signed transaction cannot be modified (Sealing check)."""
     sk = SigningKey.generate()
     sender_hex = sk.verify_key.encode(encoder=HexEncoder).decode()
     tx = Transaction(sender=sender_hex, receiver="bob", amount=100, nonce=1)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,43 +2,30 @@ from minichain.transaction import Transaction
 from nacl.signing import SigningKey
 from nacl.encoding import HexEncoder
 
+
 def test_tx_caching():
-    """Verifies standard lifecycle caching: None -> Filled -> Cleared by Sign."""
     sk = SigningKey.generate()
     sender_hex = sk.verify_key.encode(encoder=HexEncoder).decode()
-    
     tx = Transaction(sender=sender_hex, receiver="addr", amount=100, nonce=1)
 
-    # 1. Initial State
     assert tx._cached_tx_id is None
-
-    # 2. First access (triggers calculation)
     first_id = tx.tx_id
     assert tx._cached_tx_id == first_id
+    assert tx.tx_id == first_id  # second access, same result
 
-    # 3. Signing (must clear cache automatically via __setattr__)
     tx.sign(sk)
     assert tx._cached_tx_id is None
 
-    # 4. Re-calculate after sign
     signed_id = tx.tx_id
     assert signed_id != first_id
     assert tx._cached_tx_id == signed_id
 
+
 def test_tx_mutation_clears_cache():
-    """Verifies that direct field updates also clear the cache (Bulletproof check)."""
     tx = Transaction(sender="alice", receiver="bob", amount=100, nonce=1)
-    
-    # 1. Fill the cache
     original_id = tx.tx_id
     assert tx._cached_tx_id is not None
-    
-    # 2. Mutate a field directly (e.g., changing the amount)
+
     tx.amount = 500
-    
-    # 3. ASSERT: Cache must be None immediately after mutation
     assert tx._cached_tx_id is None
-    
-    # 4. ASSERT: New ID must be different from the old one
-    new_id = tx.tx_id
-    assert new_id != original_id
+    assert tx.tx_id != original_id

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,44 @@
+from minichain.transaction import Transaction
+from nacl.signing import SigningKey
+from nacl.encoding import HexEncoder
+
+def test_tx_caching():
+    # 1. Setup a dummy transaction
+    sk = SigningKey.generate()
+    sender_hex = sk.verify_key.encode(encoder=HexEncoder).decode()
+    
+    tx = Transaction(
+        sender=sender_hex,
+        receiver="receiver_addr",
+        amount=100,
+        nonce=1
+    )
+
+    print(f"--- Initial State ---")
+    print(f"Cache value: {tx._cached_tx_id}") # Should be None
+
+    # 2. First access (triggers calculation)
+    first_id = tx.tx_id
+    print(f"\n--- After First Access ---")
+    print(f"Calculated ID: {first_id}")
+    print(f"Cache value: {tx._cached_tx_id}") # Should now be the hash
+
+    # 3. Second access (should be instant)
+    second_id = tx.tx_id
+    print(f"\n--- After Second Access ---")
+    print(f"Is it the same ID? {first_id == second_id}")
+    
+    # 4. Signing (should clear cache)
+    print(f"\n--- Signing Transaction ---")
+    tx.sign(sk)
+    print(f"Cache value after sign: {tx._cached_tx_id}") # Should be None again
+
+    # 5. Access after signing (re-calculates with signature)
+    signed_id = tx.tx_id
+    print(f"\n--- After Accessing Signed TX ---")
+    print(f"New Signed ID: {signed_id}")
+    print(f"Cache value: {tx._cached_tx_id}")
+    print(f"Did ID change? {signed_id != first_id}")
+
+if __name__ == "__main__":
+    test_tx_caching()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+import pytest
 from minichain.transaction import Transaction
 from nacl.signing import SigningKey
 from nacl.encoding import HexEncoder
@@ -29,3 +30,19 @@ def test_tx_mutation_clears_cache():
     tx.amount = 500
     assert tx._cached_tx_id is None
     assert tx.tx_id != original_id
+
+def test_signed_tx_is_sealed():
+    # 1. Generate a real key
+    sk = SigningKey.generate()
+    # 2. Get the actual hex address for that key
+    sender_hex = sk.verify_key.encode(encoder=HexEncoder).decode()
+    
+    # 3. Use that real address as the sender
+    tx = Transaction(sender=sender_hex, receiver="bob", amount=100, nonce=1)
+    
+    # 4. Now the signature will be accepted
+    tx.sign(sk)
+    
+    # 5. Assert that it is indeed sealed
+    with pytest.raises(AttributeError, match="Transaction is sealed"):
+        tx.amount = 500

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -32,17 +32,12 @@ def test_tx_mutation_clears_cache():
     assert tx.tx_id != original_id
 
 def test_signed_tx_is_sealed():
-    # 1. Generate a real key
+    """Verifies that a signed transaction cannot be modified."""
     sk = SigningKey.generate()
-    # 2. Get the actual hex address for that key
     sender_hex = sk.verify_key.encode(encoder=HexEncoder).decode()
-    
-    # 3. Use that real address as the sender
     tx = Transaction(sender=sender_hex, receiver="bob", amount=100, nonce=1)
     
-    # 4. Now the signature will be accepted
     tx.sign(sk)
     
-    # 5. Assert that it is indeed sealed
     with pytest.raises(AttributeError, match="Transaction is sealed"):
         tx.amount = 500

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,34 +3,42 @@ from nacl.signing import SigningKey
 from nacl.encoding import HexEncoder
 
 def test_tx_caching():
-    # 1. Setup a dummy transaction
+    """Verifies standard lifecycle caching: None -> Filled -> Cleared by Sign."""
     sk = SigningKey.generate()
     sender_hex = sk.verify_key.encode(encoder=HexEncoder).decode()
     
-    tx = Transaction(
-        sender=sender_hex,
-        receiver="receiver_addr",
-        amount=100,
-        nonce=1
-    )
+    tx = Transaction(sender=sender_hex, receiver="addr", amount=100, nonce=1)
 
-    # 2. Assert Initial State (The "None" check you were worried about)
+    # 1. Initial State
     assert tx._cached_tx_id is None
 
-    # 3. First access (triggers calculation)
+    # 2. First access (triggers calculation)
     first_id = tx.tx_id
     assert tx._cached_tx_id == first_id
-    assert tx._cached_tx_id is not None
 
-    # 4. Second access (should be an instant lookup)
-    second_id = tx.tx_id
-    assert second_id == first_id
-
-    # 5. Signing (must invalidate/clear the cache)
+    # 3. Signing (must clear cache automatically via __setattr__)
     tx.sign(sk)
     assert tx._cached_tx_id is None
 
-    # 6. Access after signing (must re-calculate)
+    # 4. Re-calculate after sign
     signed_id = tx.tx_id
-    assert tx._cached_tx_id == signed_id
     assert signed_id != first_id
+    assert tx._cached_tx_id == signed_id
+
+def test_tx_mutation_clears_cache():
+    """Verifies that direct field updates also clear the cache (Bulletproof check)."""
+    tx = Transaction(sender="alice", receiver="bob", amount=100, nonce=1)
+    
+    # 1. Fill the cache
+    original_id = tx.tx_id
+    assert tx._cached_tx_id is not None
+    
+    # 2. Mutate a field directly (e.g., changing the amount)
+    tx.amount = 500
+    
+    # 3. ASSERT: Cache must be None immediately after mutation
+    assert tx._cached_tx_id is None
+    
+    # 4. ASSERT: New ID must be different from the old one
+    new_id = tx.tx_id
+    assert new_id != original_id

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -37,12 +37,25 @@ def test_tx_caching_efficiency():
         assert mock_hash.call_count == 2
 
 def test_signed_tx_is_sealed():
-    """Verifies that a signed transaction cannot be modified (Sealing check)."""
+    """Verifies that a signed transaction clears cache, changes ID, and cannot be modified."""
     sk = SigningKey.generate()
     sender_hex = sk.verify_key.encode(encoder=HexEncoder).decode()
     tx = Transaction(sender=sender_hex, receiver="bob", amount=100, nonce=1)
     
+    # 1. Grab the ID before signing
+    unsigned_id = tx.tx_id
+    assert tx._cached_tx_id == unsigned_id
+    
+    # 2. Sign it
     tx.sign(sk)
     
+    # 3. Prove signing killed the old cache
+    assert tx._cached_tx_id is None
+    
+    # 4. Prove the new ID is totally different
+    signed_id = tx.tx_id
+    assert signed_id != unsigned_id
+    
+    # 5. Prove it's locked down (Sealed)
     with pytest.raises(AttributeError, match="Transaction is sealed"):
         tx.amount = 500


### PR DESCRIPTION
### **Description**
Currently, the `Transaction.tx_id` property re-computes a SHA-256 hash every time the identifier is requested. During high-load operations like block validation or full-node syncing, the CPU performs these expensive cryptographic operations many times for the same static data.

This PR introduces a **caching pattern** (memoization) that stores the result of the first hash calculation and reuses it for all subsequent calls. This ensures that accessing a transaction's ID is a near-instant memory lookup rather than a repeated cryptographic operation.

### **Addressed Issues:**
Fixes #74 

### **Screenshots/Recordings:**
Verified the logic with a dedicated test script (`tests/test_cache.py`). 

```bash
========================================= test session starts =========================================
platform win32 -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
rootdir: C:\Users\Xavier\MiniChain
plugins: anyio-4.10.0
collected 2 items

tests\test_cache.py ..                                                                           [100%] 

========================================== 2 passed in 0.53s ==========================================
```

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.
I have used the following AI models and tools: Gemini 3 Flash

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction IDs are now computed once and cached for faster repeated access; cache is cleared and recomputed after signing or when any transaction field changes.
  * Transactions become sealed after signing and raise on further modifications.
  * Timestamp input normalized: values <1e12 treated as seconds (converted/rounded to ms); larger values treated as ms.

* **Tests**
  * Added tests for ID caching efficiency, cache invalidation on mutation/signing, and sealing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StabilityNexus/MiniChain/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->